### PR TITLE
Fix for flask_recruiting_trade NaN

### DIFF
--- a/FLASK-TOOLS.user.js
+++ b/FLASK-TOOLS.user.js
@@ -6240,7 +6240,7 @@ var LANG = {
                     // DropDown-Button for ratio
                 '<div class="border-left"></div>' +
                 '<div class="border-right"></div>' +
-                '<div class="caption" name="' + percent + '">' + Math.round(percent * 100) + '%</div>' +
+		'<div class="caption" name="' + percent + '">' + (percent == "auto" ? "auto" : `${Math.round(percent * 100)}%`) + '</div>' +
                 '<div class="arrow"></div>' +
                 '</div><span class="rec_count">(' + trade_count + ')</span></div>').appendTo(wndID + ".content");
 


### PR DESCRIPTION
fix for the market, if the percent it's set to "auto", when it's tried to be parsed into the math.round get buggy and display NaN

the place auto when it's needed and the percentual otherwise